### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,5 @@ Jinja2
 PyGithub
 PyMongo
 docker>=4.1.0
+websocket-client==0.53.0
 agavepy@git+https://github.com/TACC/agavepy.git@cli


### PR DESCRIPTION
pinning the version of websocket client. The newest version causes entrypoint errors with `tapis --help`, to reproduce:
```
docker run --rm -it jurrutia/cli-test:022020
git clone https://github.com/TACC-Cloud/tapis-cli-ng.git
cd tapis-cli-ng
pip3 install --upgrade .
tapis --help
pip3 install --upgrade websocket-client
tapis --help
```