### PR TITLE
remove strftime(%s) for getting the current time in "epoch" format

### DIFF
--- a/tapis_cli/templating/variables/date_time.py
+++ b/tapis_cli/templating/variables/date_time.py
@@ -19,9 +19,7 @@ def key_values():
     date_time_facts['hour'] = now.strftime('%H')
     date_time_facts['minute'] = now.strftime('%M')
     date_time_facts['second'] = now.strftime('%S')
-    date_time_facts['epoch'] = now.strftime('%s')
-    if date_time_facts['epoch'] == '' or date_time_facts['epoch'][0] == '%':
-        date_time_facts['epoch'] = str(int(time.time()))
+    date_time_facts['epoch'] = str(int(time.time()))
     date_time_facts['date'] = now.strftime('%Y-%m-%d')
     date_time_facts['time'] = now.strftime('%H:%M:%S')
     date_time_facts['iso8601_micro'] = now.utcnow().strftime(


### PR DESCRIPTION
The "%s" format is not specifically supported by datetime.strftime and was being passed up to the system interpreter.  This was failing on Windows with the error message "Invalid format string."

From testing in Windows powershell, this PR resolves Issue #338.

datetime.timestamp() was another valid way to get Epoch time in Python3, but it is not compatible with Python2.  I think time.time() is sufficient in all cases.