### PR TITLE
help message fix and syntax improvement

### DIFF
--- a/tapis_cli/commands/taccapis/v2/actors/deploy/deploy.py
+++ b/tapis_cli/commands/taccapis/v2/actors/deploy/deploy.py
@@ -319,7 +319,7 @@ class ActorsDeploy(ActorsFormatManyUnlimited, DockerPy, WorkingDirectoryArg,
                                                           '').split(',')
                 users = [u.strip() for u in users]
                 for u in users:
-                    if u is not '' and u not in granted:
+                    if u != '' and u not in granted:
                         body = {'username': u, 'permission': pem[1]}
                         resp = self.tapis_client.actors.updatePermissions(
                             actorId=self.actor_id, body=body)

--- a/tapis_cli/commands/taccapis/v2/apps/deploy/deploy.py
+++ b/tapis_cli/commands/taccapis/v2/apps/deploy/deploy.py
@@ -480,7 +480,7 @@ class AppsDeploy(AppsFormatManyUnlimited, DockerPy, WorkingDirectoryArg,
                 users = self.config['grants'].get(pem[0], '').split(',')
                 users = [u.strip() for u in users]
                 for u in users:
-                    if u is not '' and u not in granted:
+                    if u != '' and u not in granted:
                         if pems.grant(self._app_id(),
                                       u,
                                       pem[1],

--- a/tapis_cli/commands/taccapis/v2/jobs/outputs_download.py
+++ b/tapis_cli/commands/taccapis/v2/jobs/outputs_download.py
@@ -5,14 +5,14 @@ from tapis_cli.utils import makedirs
 from . import API_NAME, SERVICE_VERSION
 from .mixins import JobsUUID
 from ..files.models import File
-from ..files.formatters import FilesFormatOne
+from .formatters import JobsFormatOne
 from .helpers.sync import download
 from ..files.mixins import ExcludeFiles, IncludeFiles, OverwritePolicy, ReportProgress
 
 __all__ = ['JobsOutputsDownload']
 
 
-class JobsOutputsDownload(FilesFormatOne, JobsUUID, RemoteFilePath,
+class JobsOutputsDownload(JobsFormatOne, JobsUUID, RemoteFilePath,
                           ExcludeFiles, IncludeFiles, OverwritePolicy,
                           ReportProgress):
 

--- a/tapis_cli/commands/taccapis/v2/jobs/outputs_list.py
+++ b/tapis_cli/commands/taccapis/v2/jobs/outputs_list.py
@@ -3,7 +3,7 @@ from tapis_cli.display import Verbosity
 from tapis_cli.clients.services.mixins import RemoteFilePath
 
 from ..files.models import File
-from ..files.formatters import FilesFormatMany
+from .formatters import JobsFormatMany
 from ..files.mixins import FilesOptions
 # Note - this is the jobs-outputs specific listdir!
 from .helpers.walk import listdir
@@ -11,7 +11,7 @@ from .mixins import JobsUUID
 from . import API_NAME, SERVICE_VERSION
 
 
-class JobsOutputsList(FilesFormatMany, JobsUUID, FilesOptions, RemoteFilePath):
+class JobsOutputsList(JobsFormatMany, JobsUUID, FilesOptions, RemoteFilePath):
 
     HELP_STRING = 'Lists output directory for a Jobs'
     LEGACY_COMMMAND_STRING = 'jobs-output-list'


### PR DESCRIPTION
1) Changed FILE_UUID and JOB_UUID in the `jobs output list` and `jobs output download` help message. 
2) Changed syntax to suppress this message: 

```/Users/brandikuritz/git/tapis-cli/tapis_cli/commands/taccapis/v2/actors/deploy/deploy.py:322: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if u is not '' and u not in granted:

/Users/brandikuritz/git/tapis-cli/tapis_cli/commands/taccapis/v2/apps/deploy/deploy.py:483: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if u is not '' and u not in granted:
```